### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,3 +13,5 @@ services:
       NEKO_PASSWORD_ADMIN: admin
       NEKO_EPR: 52000-52100
       NEKO_ICELITE: 1
+    cap_add:
+      - SYS_ADMIN


### PR DESCRIPTION
through  the addition parameter neko virtual browser will show page on the browser.

otherwise what happen:
container is running but not able to see the website on the browser ( home page of neko )

as already mentioned on official documentation
**if we are using docker compose**
![image](https://github.com/jaiswaladi246/Vitual-Browser/assets/138249606/5360ae00-cfd8-4d35-a75f-d659cde509af)
 

cap_add:
 - SYS_ADMIN